### PR TITLE
fix: the build script must not run from its current location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+CMakeLists.txt
+foo
+*.save


### PR DESCRIPTION
This is to make sure that the script that we are building with is not run from the current location. This is because the actual location for the source files is in the other location. We are also making sure that in case the path to the build output is not absolute, we will change this to be absolute to ensure that we are executing with value path.